### PR TITLE
Update build configuration to use Shadow plugin for fat JAR creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,25 @@ Dropbox→GitまたはGit→Dropboxの同期方向を選択でき、差分のみ
 ## 使い方
 1. `src/main/resources/config.properties.template` をコピーし、必要な値を設定して `config.properties` を作成します。
 2. 必要な認証情報（Dropbox・GitHubのトークン等）を設定します。
-3. Gradleでビルドします。
+3. Gradleでビルドします（Shadow Pluginを使用してFat JARを作成）。
 	```cmd
-	gradlew.bat build
+	gradlew.bat shadowJar
 	```
 4. アプリケーションを実行します（同期方向は `--direction` で指定）。
 	```cmd
-	java -jar build/libs/dbx-git-sync-<version>.jar --config C:\path\to\config.properties --direction dbx-to-git
+	java -jar build/libs/dbx-git-sync.jar --config C:\path\to\config.properties --direction dbx-to-git
 	```
-	- `--direction dbx-to-git` : Dropbox -> Git 同期（既存処理と同等）
-	- `--direction git-to-dbx` : Git -> Dropbox 同期（旧git-dbx-syncの機能）
+	- `--direction dbx-to-git` : Dropbox → Git 同期（既存処理と同等）
+	- `--direction git-to-dbx` : Git → Dropbox 同期（旧git-dbx-syncの機能）
 
-	例（Git->Dropbox）：
+	例（Git→Dropbox）：
 	```cmd
-	java -jar build/libs/dbx-git-sync-1.0.0.jar --config C:\tmp\config\config.properties --direction git-to-dbx
+	java -jar build/libs/dbx-git-sync.jar --config C:\tmp\config\config.properties --direction git-to-dbx
 	```
+
+	**注意事項:**
+	- オプション名（`--config`、`--direction`）は**大文字小文字を区別します**（必ず小文字で指定）
+	- 同期方向の値（`dbx-to-git`、`git-to-dbx`）は大文字小文字を区別しません（`DBX-TO-GIT`、`Dbx-To-Git`等も可）
 
 ## 同期方向
 
@@ -94,6 +98,17 @@ sync.target.dir=review
 # カーソル管理
 cursor.file.path=C:/path/to/cursor
 ```
+
+## 技術情報
+
+### 必要環境
+- **Java**: 17以上
+- **Gradle**: 8.10.2（Wrapper使用を推奨）
+
+### ビルドシステム
+- Shadow Plugin 8.1.1を使用してFat JARを生成
+- すべての依存関係（Dropbox SDK、JGit、Logback等）を含む単一の実行可能JAR
+- 詳細は `solution/shadow-plugin-gradle-compatibility.md` を参照
 
 ---
 This application synchronizes files between Dropbox and GitHub repositories. Use `--direction dbx-to-git|git-to-dbx` to choose the flow.

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,10 @@
  */
 
 plugins {
-    // Apply the application plugin to add support for building a CLI application in Java.
-    id 'application'
+    // Apply the java plugin for building Java projects
+    id 'java'
+    // Shadow plugin for creating fat JAR with all dependencies
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 repositories {
@@ -50,12 +52,6 @@ java {
     }
 }
 
-application {
-    // Define the main class for the application.
-    // Use the fully-qualified main class name and the recommended API
-    mainClass.set('com.db2ghsync.DropboxGitSyncApplication')
-}
-
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
@@ -70,4 +66,31 @@ jar {
             'Main-Class': 'com.db2ghsync.DropboxGitSyncApplication'
         )
     }
+}
+
+// Shadow JAR configuration for creating executable fat JAR
+shadowJar {
+    archiveBaseName.set('dbx-git-sync')
+    archiveClassifier.set('')
+    archiveVersion.set('')
+    
+    // Configure manifest
+    manifest {
+        attributes(
+            'Main-Class': 'com.db2ghsync.DropboxGitSyncApplication',
+            'Implementation-Title': 'Dropbox Git Sync',
+            'Implementation-Version': project.version
+        )
+    }
+    
+    // Merge service files to avoid conflicts
+    mergeServiceFiles()
+    
+    // Exclude signature files to avoid security exceptions
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
+}
+
+// Make build task depend on shadowJar
+tasks.build {
+    dependsOn shadowJar
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Replaced the application plugin with the java plugin for better project structure.
- Added Shadow plugin (version 8.1.1) to create an executable fat JAR that includes all dependencies.
- Updated README to reflect changes in the build process and usage instructions.
- Adjusted gradle-wrapper.properties to use Gradle version 8.10.2 for compatibility.